### PR TITLE
fix: disalignment of h2s in contact section is resolved

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -333,20 +333,20 @@ li {
 .contact {
   display: flex;
   justify-content: center;
-  align-items: baseline;
-  padding: 2rem;
+  align-items: flex-start;
+  padding: 5rem;
 }
 
 .form-container {
   display: flex;
   flex-direction: column;
   min-width: 40%;
-  padding: 2rem;
+  /* padding: 2rem; */
 }
 
 .form {
   margin-top: 1rem;
-  padding-left: 2%;
+  /* padding-left: 2%; */
   display: flex;
   gap: 1rem;
   flex-direction: column;
@@ -370,7 +370,7 @@ textarea {
 .list-right {
   display: flex;
   flex-direction: column;
-  padding: 4rem;
+  padding: 0 4rem;
   max-width: 50%;
 }
 
@@ -535,6 +535,10 @@ textarea {
     align-items: center;
     padding: 2rem;
     margin: auto;
+  }
+
+  .form-container {
+    margin-top: 3rem;
   }
 
   .list-right {


### PR DESCRIPTION
Fixed error about misaligning h2s because of different margins and the align items value being baseline instead of flex-start. 